### PR TITLE
Small update to WinDriverService class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.windriverteam</groupId>
     <artifactId>windriver-java</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <name>windriver-java</name>
@@ -92,6 +92,19 @@
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>fully.qualified.MainClass</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                   </descriptorRefs>
+               </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/ua/windriver/core/WinDriverService.java
+++ b/src/main/java/ua/windriver/core/WinDriverService.java
@@ -129,8 +129,38 @@ public class WinDriverService {
         return find(request);
     }
 
+    private ElementLocationControlResponse findWindowsByScopeOption(PropertyConditions conditions, SearchScopeOption scopeOption) {
+        ElementLocationControlRequest request = new ElementLocationControlRequest();
+        request.setTreeWalkerType("");
+        request.setSearchScope(scopeOption);
+        request.setParentWinDriverElementId("");
+        request.setFindOption(FindOption.FIND_ALL);
+        request.setConditionModels(conditions.getConditions());
+        return find(request);
+    }
+
+    private ElementLocationControlResponse findWindowsByRootNode(PropertyConditions conditions, WinDriverElement root, SearchScopeOption scopeOption) {
+        ElementLocationControlRequest request = new ElementLocationControlRequest();
+        request.setTreeWalkerType("");
+        request.setSearchScope(scopeOption);
+        request.setParentWinDriverElementId(root.getElement().getWinDriverElementId());
+        request.setFindOption(FindOption.FIND_ALL);
+        request.setConditionModels(conditions.getConditions());
+        return find(request);
+    }
+
     public <T extends WinDriverElement> T getWindow(PropertyConditions conditions) {
         Map result = findWindowsByCondition(conditions).getPayload().get(0);
+        return convertMapToWinDriverObject(result, winDriverElementType);
+    }
+
+    public <T extends WinDriverElement> T getWindowsByScopeOption (PropertyConditions conditions, SearchScopeOption scopeOption) {
+        Map result = findWindowsByScopeOption(conditions, scopeOption).getPayload().get(0);
+        return convertMapToWinDriverObject(result, winDriverElementType);
+    }
+
+    public <T extends WinDriverElement> T getWindowsByRootNode (PropertyConditions conditions, WinDriverElement root, SearchScopeOption scopeOption) {
+        Map result = findWindowsByRootNode(conditions, root, scopeOption).getPayload().get(0);
         return convertMapToWinDriverObject(result, winDriverElementType);
     }
 


### PR DESCRIPTION
added methods 'getWindowsByScopeOption()' and 'getWindowsByRootNode()' which allow to search windows up and down in hierarchy and also up and down from the selected root node. 